### PR TITLE
lag in hover

### DIFF
--- a/config/tab-title.lua
+++ b/config/tab-title.lua
@@ -123,7 +123,7 @@ M.setup = function()
       -- Right semi-circle
       M.push(fg, bg, { Intensity = "Bold" }, GLYPH_SEMI_CIRCLE_RIGHT)
 
-      return wezterm.format(M.cells)
+      return M.cells
    end)
 end
 


### PR DESCRIPTION
Return return wezterm.format(M.cells) causes lag when hovering through the tabs, several are left selected, understanding that it is slower.

Just return return M.cells fix the bug.