### PR TITLE
feat: random background images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /lua.bat
 /lua_modules
 /.luarocks
+.DS_Store

--- a/config/appearance.lua
+++ b/config/appearance.lua
@@ -1,6 +1,25 @@
 local wezterm = require('wezterm')
 local colors = require('colors.custom')
 -- local fonts = require('config.fonts')
+local backgrounds_dir = wezterm.config_dir .. '/backdrops'
+local backgrounds = {}
+-- stores file values in array pipe
+local pipe = io.popen(string.format('ls "%s"', backgrounds_dir))
+-- creates a table of the backgrounds in the /backdrops directory
+if pipe then
+   local dir_contents = pipe:read('*a')
+   if dir_contents then
+      for file in dir_contents:gmatch('[^%\n]+') do
+         table.insert(backgrounds, file)
+      end
+   end
+   if not pipe:close() then
+      print('Failed to close pipe')
+   end
+end
+-- Selects a random value between min and max of backgrounds and stores the index return as the random_background at load
+local random_index = math.random(#backgrounds)
+local random_background = backgrounds[random_index]
 
 return {
    animation_fps = 60,
@@ -14,7 +33,7 @@ return {
    -- background
    background = {
       {
-         source = { File = wezterm.config_dir .. '/backdrops/space.jpg' },
+         source = { File = backgrounds_dir .. '/' .. random_background },
       },
       {
          source = { Color = colors.background },

--- a/config/fonts.lua
+++ b/config/fonts.lua
@@ -1,7 +1,7 @@
 local wezterm = require('wezterm')
 local platform = require('utils.platform')
 
-local font = 'JetBrainsMono Nerd Font'
+local font = 'JetBrainsMonoNL NF'
 local font_size = platform().is_mac and 12 or 9
 
 return {

--- a/config/launch.lua
+++ b/config/launch.lua
@@ -18,11 +18,17 @@ if platform.is_win then
       },
    }
 elseif platform.is_mac then
-   options.default_prog = { '/opt/homebrew/bin/fish' }
+   options.default_prog = { 'zsh' }
    options.launch_menu = {
       { label = 'Bash', args = { 'bash' } },
       { label = 'Fish', args = { '/opt/homebrew/bin/fish' } },
       { label = 'Nushell', args = { '/opt/homebrew/bin/nu' } },
+      { label = 'Zsh', args = { 'zsh' } },
+   }
+elseif platform.is_linux then
+   options.default_prog = { 'zsh' }
+   options.launch_menu = {
+      { label = 'Bash', args = { 'bash' } },
       { label = 'Zsh', args = { 'zsh' } },
    }
 end


### PR DESCRIPTION
I added functionality that instructs wezterm to randomly select a background when launching the terminal, rather than having to make changes to the config manually to change background.

Hello Kevin, I absolutely love this wezterm configuration, and I've forked it for myself as a bases for my own configuration. I also loved the wallpapers that you had sourced in your config, but I wanted them to be selected at random whenever I launched wezterm. I added the functionality to my configuration, and I mainly wanted to pass it over to you in case it was something you also liked the idea. Feel free to add it to the main repo if you would like. If not, that is totally fine. I figured it was small contribution to an amazing configuration that you put together. 

Thank you,