### PR TITLE
Feat/vim cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,3 +393,4 @@ Most of the key bindings revolve around a <kbd>SUPER</kbd> and <kbd>SUPER_REV</k
 - <https://github.com/catppuccin/wezterm>
 - <https://github.com/wez/wezterm/discussions/628#discussioncomment-1874614>
 - <https://github.com/wez/wezterm/discussions/628#discussioncomment-5942139>
+- <https://github.com/haikali3/wezterm-config?tab=readme-ov-file>

--- a/config/appearance.lua
+++ b/config/appearance.lua
@@ -18,6 +18,16 @@ return {
    default_cursor_style = 'BlinkingBlock',
    cursor_blink_rate = 650,
 
+   -- vim cursor
+   cursor_styles = {
+      vim_insert = {
+         cursor_style = 'BlinkingBlock',
+      },
+      vim_normal = {
+         cursor_style = 'Block',
+      },
+   },
+
    -- color scheme
    colors = colors,
 

--- a/config/bindings.lua
+++ b/config/bindings.lua
@@ -54,8 +54,10 @@ local keys = {
    { key = 'Backspace',  mods = mod.SUPER,     action = act.SendString '\u{15}' },
 
    -- copy/paste --
-   { key = 'c',          mods = 'CTRL|SHIFT',  action = act.CopyTo('Clipboard') },
-   { key = 'v',          mods = 'CTRL|SHIFT',  action = act.PasteFrom('Clipboard') },
+   { key = 'c',          mods = mod.SUPER,  action = act.CopyTo('Clipboard') },
+   { key = 'v',          mods = mod.SUPER,  action = act.PasteFrom('Clipboard') },
+   -- { key = 'c',          mods = 'CTRL|SHIFT',  action = act.CopyTo('Clipboard') },
+   -- { key = 'v',          mods = 'CTRL|SHIFT',  action = act.PasteFrom('Clipboard') },
 
    -- tabs --
    -- tabs: spawn+close

--- a/config/bindings.lua
+++ b/config/bindings.lua
@@ -243,7 +243,8 @@ local mouse_bindings = {
 return {
    disable_default_key_bindings = true,
    -- disable_default_mouse_bindings = true,
-   leader = { key = 'Space', mods = mod.SUPER_REV },
+   -- leader = { key = 'Space', mods = mod.SUPER_REV },
+   leader = { key = '>', mods = 'NONE' },
    keys = keys,
    key_tables = key_tables,
    mouse_bindings = mouse_bindings,

--- a/config/bindings.lua
+++ b/config/bindings.lua
@@ -235,7 +235,7 @@ local mouse_bindings = {
    -- Ctrl-click will open the link under the mouse cursor
    {
       event = { Up = { streak = 1, button = 'Left' } },
-      mods = 'CTRL',
+      mods = 'SUPER',
       action = act.OpenLinkAtMouseCursor,
    },
 }

--- a/config/launch.lua
+++ b/config/launch.lua
@@ -19,10 +19,10 @@ if platform.is_win then
       },
    }
 elseif platform.is_mac then
-   options.default_prog = { '/opt/homebrew/bin/fish', '-l' }
+   options.default_prog = { '/usr/local/bin/fish', '-l' }
    options.launch_menu = {
       { label = 'Bash', args = { 'bash', '-l' } },
-      { label = 'Fish', args = { '/opt/homebrew/bin/fish', '-l' } },
+      { label = 'Fish', args = { '/usr/local/bin/fish', '-l' } },
       { label = 'Nushell', args = { '/opt/homebrew/bin/nu', '-l' } },
       { label = 'Zsh', args = { 'zsh', '-l' } },
    }

--- a/config/launch.lua
+++ b/config/launch.lua
@@ -22,7 +22,9 @@ elseif platform.is_mac then
    options.default_prog = { '/usr/local/bin/fish', '-l' }
    options.launch_menu = {
       { label = 'Bash', args = { 'bash', '-l' } },
+      -- local mac
       { label = 'Fish', args = { '/usr/local/bin/fish', '-l' } },
+
       { label = 'Nushell', args = { '/opt/homebrew/bin/nu', '-l' } },
       { label = 'Zsh', args = { 'zsh', '-l' } },
    }

--- a/events/vim-mode.lua
+++ b/events/vim-mode.lua
@@ -1,0 +1,28 @@
+local wezterm = require('wezterm')
+
+local M = {}
+
+M.setup = function()
+   wezterm.on('update-status', function(window, pane)
+      local mode = pane:get_foreground_process_name()
+      if mode:find('vim') then
+         -- Check if we're in normal mode by looking for the "-- NORMAL --" text
+         local success, stdout, stderr = wezterm.run_child_process({'sh', '-c', 'ps -p ' .. pane:get_foreground_process_id() .. ' -o command='})
+         if success and stdout:find('-- NORMAL --') then
+            window:set_config_overrides({
+               cursor_style = 'Block'
+            })
+         else
+            window:set_config_overrides({
+               cursor_style = 'BlinkingBlock'
+            })
+         end
+      else
+         window:set_config_overrides({
+            cursor_style = 'BlinkingBlock'
+         })
+      end
+   end)
+end
+
+return M 

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -10,6 +10,7 @@ require('events.left-status').setup()
 require('events.right-status').setup({ date_format = '%a %H:%M:%S' })
 require('events.tab-title').setup({ hide_active_tab_unseen = false, unseen_icon = 'circle' })
 require('events.new-tab-button').setup()
+require('events.vim-mode').setup()
 
 return Config:init()
    :append(require('config.appearance'))


### PR DESCRIPTION
This pull request introduces several enhancements and adjustments to the WezTerm configuration, focusing on improved appearance, key bindings, platform-specific configurations, and new event handling for Vim mode. Below is a summary of the most significant changes:

### Appearance Enhancements
* Added `cursor_styles` configuration in `config/appearance.lua` to define different cursor styles for Vim's insert and normal modes. (`[config/appearance.luaR21-R30](diffhunk://#diff-48d2818a679f18a970d90f8d123cf5ab4633750c7c648576d71324c38f243c40R21-R30)`)

### Key Binding Updates
* Updated key bindings in `config/bindings.lua` to replace `CTRL|SHIFT` with `SUPER` for copy and paste actions. (`[config/bindings.luaL57-R60](diffhunk://#diff-106b9fa47f863c4555e9f4df6a6a1b25679ad7d64f2f1bb2f21e7790335dbb86L57-R60)`)
* Modified mouse binding to use `SUPER` instead of `CTRL` for opening links at the mouse cursor. (`[config/bindings.luaL238-R249](diffhunk://#diff-106b9fa47f863c4555e9f4df6a6a1b25679ad7d64f2f1bb2f21e7790335dbb86L238-R249)`)
* Changed the leader key binding to use `>` with no modifiers instead of `Space` with `SUPER_REV`. (`[config/bindings.luaL238-R249](diffhunk://#diff-106b9fa47f863c4555e9f4df6a6a1b25679ad7d64f2f1bb2f21e7790335dbb86L238-R249)`)

### Platform-Specific Adjustments
* Updated the default shell path for macOS in `config/launch.lua` to use `/usr/local/bin/fish` instead of `/opt/homebrew/bin/fish`. (`[config/launch.luaL22-R27](diffhunk://#diff-17f5f7ca4809d989824a98844cabf07194dff9bd3b7f2b602f6809480c360732L22-R27)`)

### New Event Handling
* Added a new `events/vim-mode.lua` module to dynamically adjust the cursor style based on Vim's mode by detecting the foreground process. (`[events/vim-mode.luaR1-R28](diffhunk://#diff-aa4f4483da4358517008ca8cb20aad2ae907993fe2f72771584dfd8f6534d9c7R1-R28)`)
* Integrated the new `vim-mode` event handler in the main configuration file `wezterm.lua`. (`[wezterm.luaR13](diffhunk://#diff-ca68a76bde837819cd11f568261e779d5c053a6aeee5f2eb1cc451338d07170eR13)`)

### Documentation Update
* Added a new link to the `README.md` for a custom WezTerm configuration repository. (`[README.mdR396](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R396)`)