### PR TITLE
docs: cleanup homebrew-cask-fonts commdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,7 @@
     Install with Homebrew (Macos)
 
     ```sh
-    brew tap homebrew/cask-fonts
-    brew install font-jetbrains-mono-nerd-font
+    brew install --cask font-jetbrains-mono-nerd-font
     ```
 
     Install with Scoop (Windows)


### PR DESCRIPTION
homebrew-cask-fonts was deprecated in https://github.com/Homebrew/homebrew-linux-fonts/issues/42